### PR TITLE
Handling error when result is 'error code: 1015', this happens when username is out of syntax.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,12 @@ const fetchData = (url: string) =>
             if (!result) {
                 reject(err);
             }
-            resolve(JSON.parse(result));
+            try {
+                const jsonResult = JSON.parse(result);
+                resolve(jsonResult);
+            } catch (error) {
+                reject(error);
+            }
         });
     });
 


### PR DESCRIPTION
@iFraan Try pass username too large (Lorem Ipsum text for example), 'result' will be 'error code: 1015', and JSON.parse(result) throw an error that crashes the server. 